### PR TITLE
Fix imprecise Result path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! ```rust,ignore
 //! impl Display for FooBar {
-//!     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+//!     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
 //!         match *self {
 //!             FooBar::Foo => f.write_str("Foo"),
 //!             FooBar::Bar => f.write_str("Bar()"),
@@ -93,7 +93,7 @@ fn impl_display(name: &syn::Ident, variants: &[syn::Variant]) -> quote::Tokens {
 
     quote! {
         impl Display for #name {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
                 match *self {
                     #(#variants)*
                 }


### PR DESCRIPTION
It's a common pattern in large crates to define a custom `Error` type, then define an alias `type Result<T> = std::result::Result<T, Error>`. Unfortunately, this proc macro referred to `Result`, not `::std::result::Result`, so it would resolve to the custom type.