### PR TITLE
do not require the user to import std::fmt::Display

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enum-display-derive"
-version = "0.1.2-alpha.0"
+version = "0.1.2-alpha.1"
 authors = ["Tibor Benke <ihrwein@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://docs.rs/enum-display-derive"
 description = """
 Display trait's custom derive for simple enums.
 """
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ like the following one:
 #[macro_use]
 extern crate enum_display_derive;
 
-use std::fmt::Display;
-
 #[derive(Display)]
 enum FizzBuzz {
    Fizz,

--- a/examples/foobar.rs
+++ b/examples/foobar.rs
@@ -1,8 +1,6 @@
 #[macro_use]
 extern crate enum_display_derive;
 
-use std::fmt::Display;
-
 #[derive(Display)]
 pub enum FooBar {
     Foo,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,8 +90,8 @@ fn impl_display(name: &syn::Ident, data: &syn::DataEnum) -> proc_macro2::TokenSt
         .map(|variant| impl_display_for_variant(name, variant));
 
     quote! {
-        impl std::fmt::Display for #name {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
+        impl ::core::fmt::Display for #name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::result::Result<(), ::core::fmt::Error> {
                 match *self {
                     #(#variants)*
                 }
@@ -122,7 +122,7 @@ fn impl_display_for_variant(name: &syn::Ident, variant: &syn::Variant) -> proc_m
             1 => {
                 quote! {
                     #name::#id(ref inner) => {
-                        ::std::fmt::Display::fmt(inner, f)
+                        ::core::fmt::Display::fmt(inner, f)
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ fn impl_display(name: &syn::Ident, data: &syn::DataEnum) -> proc_macro2::TokenSt
         .map(|variant| impl_display_for_variant(name, variant));
 
     quote! {
-        impl Display for #name {
+        impl std::fmt::Display for #name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
                 match *self {
                     #(#variants)*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,9 @@
 //!
 //! Actually, the most complex enum definition that this crate supports is like this one:
 //!
-//! ```rust,ignore
+//! ```rust
+//! # #[no_std]
+//! # use enum_display_derive::Display;
 //! #[derive(Display)]
 //! pub enum FooBar {
 //!     Foo,
@@ -17,11 +19,11 @@
 //!
 //! ```rust,ignore
 //! impl Display for FooBar {
-//!     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
+//!     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::result::Result<(), ::core::fmt::Error> {
 //!         match *self {
 //!             FooBar::Foo => f.write_str("Foo"),
 //!             FooBar::Bar => f.write_str("Bar()"),
-//!             FooBar::FooBar(ref inner) => ::std::fmt::Display::fmt(inner, f),
+//!             FooBar::FooBar(ref inner) => ::core::fmt::Display::fmt(inner, f),
 //!         }
 //!     }
 //! }
@@ -29,11 +31,9 @@
 //!
 //! ## Examples
 //!
-//! ```rust,ignore
+//! ```rust
 //! #[macro_use]
 //! extern crate enum_display_derive;
-//!
-//! use std::fmt::Display;
 //!
 //! #[derive(Display)]
 //! enum FizzBuzz {
@@ -43,7 +43,7 @@
 //!    Number(u64),
 //! }
 //!
-//! fn fb(i: u64) {
+//! fn fb(i: u64) -> FizzBuzz {
 //!    match (i % 3, i % 5) {
 //!        (0, 0) => FizzBuzz::FizzBuzz,
 //!        (0, _) => FizzBuzz::Fizz,

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate enum_display_derive;
+use enum_display_derive::Display;
 
 #[test]
 fn test_derive() {

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -1,8 +1,6 @@
 #[macro_use]
 extern crate enum_display_derive;
 
-use std::fmt::Display;
-
 #[test]
 fn test_derive() {
     #[derive(Display)]


### PR DESCRIPTION
When using this library, one is required to manually import std::fmt::Display.
But this import is not used in the user written code, only in the generated impl.
As the user imports the macro "Display", they should not be required to also import std::fmt::Display.

this commit changes the generated code to use "std::fmt::Display" instead of "Dislay" and removes the imports in the examples.